### PR TITLE
Implement fetch recipes

### DIFF
--- a/suggestion/mocks/recipes.ts
+++ b/suggestion/mocks/recipes.ts
@@ -1,0 +1,3 @@
+// TODO: Populate this file with 50 random hashes using a script
+
+export default [0b10000, 0b10001, 0b10100];

--- a/suggestion/src/fetchRecipes.ts
+++ b/suggestion/src/fetchRecipes.ts
@@ -1,0 +1,32 @@
+import hashes from '../mocks/recipes'; // Change this data source to an API call
+
+/**
+ * Randomly fetches a list of recipe hashes starting from `startIndex`
+ * up to a total of `limit` recipes.
+ * @param limit - The maximum number of recipes returned.
+ * @param startIndex - The index to start the search. Guarantees that the index of all hashes returned is greater than this index.
+ * @returns A list of recipe hashes, the length of which is guaranteed to be <= `limit`.
+ */
+function fetchRecipes(limit: number, startIndex: number = 0) {
+    const recipes = [];
+    const seen = new Set();
+
+    while (recipes.length < limit && seen.size <= hashes.length) {
+        const index = getRandomIndex(startIndex, hashes.length - 1);
+        let nextHash = hashes[index];
+        while (seen.has(nextHash) && seen.size <= hashes.length) {
+            const nextIndex = getRandomIndex(startIndex, hashes.length - 1);
+            nextHash = hashes[nextIndex];
+        }
+        recipes.push(nextHash);
+        seen.add(nextHash);
+    }
+
+    return recipes;
+}
+
+function getRandomIndex(min: number, max: number) {
+    return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+export { fetchRecipes };


### PR DESCRIPTION
Implements `fetchRecipes`, a function that returns a list of up to `x` hashes starting at an offset `y`. Currently uses mock data in `/mocks/recipes.ts`.