### PR TITLE
Turn off no-bitwise rule in tslint config

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -18,6 +18,7 @@
         "prettier": true,
         "quotemark": [true, "single", "avoid-escape", "avoid-template", "jsx-double"],
         "semicolon": [true, "always", "strict-bound-class-methods"],
-        "triple-equals": [true, "allow-null-check", "allow-undefined-check"]
+        "triple-equals": [true, "allow-null-check", "allow-undefined-check"],
+        "no-bitwise": false
     }
 }


### PR DESCRIPTION
I added `"no-bitwise": false` to the list of rules in the tslint.json file to prevent lint warnings when using bitwise operators (which are used in the compareHash file).