### PR TITLE
Add script to seed ingredient DB

### DIFF
--- a/ingredient/init/init.ts
+++ b/ingredient/init/init.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+interface IRecipe {
+    ingredients?: string[];
+}
+
+const seedData = JSON.parse(readFileSync(resolve('init/seed.json')).toString());
+const values = Object.values(seedData);
+
+values
+    .filter((recipe) => recipe.hasOwnProperty('ingredients'))
+    .forEach((recipe: IRecipe) => {
+        const { ingredients } = recipe;
+        ingredients.forEach((description: string) => {
+            const words = description.split(' ');
+            console.log(words.slice(2, words.length - 1).join(' '));
+        });
+    });

--- a/ingredient/init/init.ts
+++ b/ingredient/init/init.ts
@@ -8,12 +8,70 @@ interface IRecipe {
 const seedData = JSON.parse(readFileSync(resolve('init/seed.json')).toString());
 const values = Object.values(seedData);
 
-values
+const pluralfy = (units: string[]) => units.map((unit) => unit + 's');
+
+const volumeUnits = ['cup', 'teaspoon', 'tablespoon', 'ounce'];
+const weightUnits = ['gram', 'pound'];
+
+const volumes = volumeUnits.concat(pluralfy(volumeUnits));
+const weights = weightUnits.concat(pluralfy(weightUnits));
+
+const matchWordToUnit = (word: string) => {
+    const trimmed = word.replace(/[()]/, '');
+    if (volumes.includes(trimmed)) {
+        return 1;
+    }
+    if (weights.includes(trimmed)) {
+        return 2;
+    }
+    if (!isNaN(parseInt(trimmed, 2))) {
+        return 3;
+    }
+    return 0;
+};
+
+const getUnit = (ingredient: string[]) => {
+    for (let index = ingredient.length - 1; index >= 0; index--) {
+        const unit = matchWordToUnit(ingredient[index]);
+        if (unit) {
+            return { unit, index };
+        }
+    }
+    return null;
+};
+
+const parseIngredient = (description: string) => {
+    const words = description.split(' ');
+    // take out ADVERTISEMENT
+    const trimmed = words.slice(0, words.length - 1);
+    const unitInfo = getUnit(trimmed);
+    if (unitInfo) {
+        const { unit, index } = unitInfo;
+        return { name: trimmed.slice(index + 1).join(' '), unit };
+    }
+};
+
+const parsedIngredients = values
     .filter((recipe) => recipe.hasOwnProperty('ingredients'))
-    .forEach((recipe: IRecipe) => {
+    .flatMap((recipe: IRecipe) => {
         const { ingredients } = recipe;
+        const parsed = [];
         ingredients.forEach((description: string) => {
-            const words = description.split(' ');
-            console.log(words.slice(2, words.length - 1).join(' '));
+            const ingr = parseIngredient(description);
+            if (ingr) {
+                parsed.push(ingr);
+            }
         });
+        return parsed;
     });
+
+const uniques = new Set();
+const result = [];
+parsedIngredients.forEach((ingredient) => {
+    if (!uniques.has(ingredient.name)) {
+        uniques.add(ingredient.name);
+        result.push(ingredient);
+    }
+});
+console.log(result.length);
+console.log('Example: ', result[0]);

--- a/ingredient/tsconfig.json
+++ b/ingredient/tsconfig.json
@@ -5,6 +5,5 @@
         "outDir": "dist",
         "sourceMap": true,
         "types": ["jest", "node"]
-    },
-    "include": ["src/**/*.ts"]
+    }
 }

--- a/ingredient/tsconfig.json
+++ b/ingredient/tsconfig.json
@@ -5,5 +5,6 @@
         "outDir": "dist",
         "sourceMap": true,
         "types": ["jest", "node"]
-    }
+    },
+    "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
Parses ingredients from a recipe database and converts it to the following form:

```
{ name: 'dried basil', unit: 1 }
```

Where `unit` corresponds to the `unit_category` field of the ingredient table in the db. Currently only parses to an array of objects, but yet to actually populate the db.