### PR TITLE
Make POST /user on ingredient service return newly generated id

### DIFF
--- a/ingredient/init/init.sql
+++ b/ingredient/init/init.sql
@@ -123,11 +123,11 @@ values
     (102, 'fd_orange', true, 3);
 
 insert into user_map
-    (id, external_id)
+    (external_id)
 values
-    (1, '54aedb94e6c12b1c0e83385f'),
-    (2, '544edb94e6c12b1c0e83355f'),
-    (3, '566edb94e6c12b1c0e83366f');
+    ('5e5f2e00ce491deb2f822b04'),
+    ('5e5f2f2a102141eb713f660e'),
+    ('5e5f3080d410e5ecabc4c9fa');
 
 insert into user_ingredient
     (user_id, ingredient_id, quantity)

--- a/ingredient/init/init.sql
+++ b/ingredient/init/init.sql
@@ -7,7 +7,7 @@
  */
 create table user_map
 (
-    id int primary key,
+    id serial primary key,
     external_id varchar(24)
 );
 
@@ -84,7 +84,7 @@ values
     (3, 'unit');
 
 /* Units - Volume */
-insert into unit 
+insert into unit
     (id, name_formal, name_symbol, value, exponent, unit_category, main_unit)
 values
     (1, 'millilitre', 'mL', 1, -3, 1, false),
@@ -94,7 +94,7 @@ values
     (5, 'tablespoon', 'tbsp', 25, -3, 1, false);
 
 /* Units - Weight */
-insert into unit 
+insert into unit
     (id, name_formal, name_symbol, value, exponent, unit_category, main_unit)
 values
     (6, 'gram', 'g', 1, 1, 2, true),
@@ -102,7 +102,7 @@ values
     (8, 'kilogram', 'kg', 1, 3, 2, false);
 
 /* Units - Unit */
-insert into unit 
+insert into unit
     (id, name_formal, name_symbol, value, exponent, unit_category, main_unit)
 values
     (9, '', '', 1, 1, 3, true);

--- a/ingredient/src/controllers/user.ts
+++ b/ingredient/src/controllers/user.ts
@@ -12,7 +12,14 @@ export const addUser = async (req: Request, res: Response) => {
 export const deleteUser = async (req: Request, res: Response) => {
     const { id } = req.params;
     return db
-        .none('DELETE FROM user_map WHERE external_id = $1', [id])
-        .then(() => res.status(204).json({ message: 'Successfully deleted user!' }))
-        .catch((error: Error) => res.status(404).json({ error }));
+        .any('SELECT * FROM user_map WHERE id = $1', [id])
+        .then((user) => {
+            if (user.length > 0) {
+                return db.none('DELETE FROM user_map WHERE id = $1', [id]);
+            } else {
+                throw new Error('User does not exist in database');
+            }
+        })
+        .then(() => res.status(200).json({ message: 'Successfully deleted user!' }))
+        .catch((error: Error) => res.status(404).send({ error: error.message }));
 };

--- a/ingredient/src/controllers/user.ts
+++ b/ingredient/src/controllers/user.ts
@@ -1,17 +1,16 @@
 import { Request, Response } from 'express';
 import { db } from '../db/connection';
 
-let internalId = 0;
-
 export const addUser = async (req: Request, res: Response) => {
+    console.log('add user');
     const { externalId } = req.body;
     return db
-        .none('INSERT INTO user_map VALUES ($1, $2)', [internalId++, externalId])
-        .then(() => res.status(201).json({ message: 'Successfully added user!' }))
+        .one('INSERT INTO user_map (external_id) VALUES ($1) RETURNING id', [externalId])
+        .then(({ id }: { id: number }) => res.status(201).json({ id }))
         .catch((error: Error) => res.status(400).json({ error }));
 };
 
-export const deleteUser = (req: Request, res: Response) => {
+export const deleteUser = async (req: Request, res: Response) => {
     const { id } = req.params;
     return db
         .none('DELETE FROM user_map WHERE external_id = $1', [id])

--- a/ingredient/src/controllers/user.ts
+++ b/ingredient/src/controllers/user.ts
@@ -2,7 +2,6 @@ import { Request, Response } from 'express';
 import { db } from '../db/connection';
 
 export const addUser = async (req: Request, res: Response) => {
-    console.log('add user');
     const { externalId } = req.body;
     return db
         .one('INSERT INTO user_map (external_id) VALUES ($1) RETURNING id', [externalId])

--- a/ingredient/src/controllers/user.ts
+++ b/ingredient/src/controllers/user.ts
@@ -6,7 +6,7 @@ export const addUser = async (req: Request, res: Response) => {
     return db
         .one('INSERT INTO user_map (external_id) VALUES ($1) RETURNING id', [externalId])
         .then(({ id }: { id: number }) => res.status(201).json({ id }))
-        .catch((error: Error) => res.status(400).json({ error }));
+        .catch((error: Error) => res.status(400).json({ error: error.message }));
 };
 
 export const deleteUser = async (req: Request, res: Response) => {
@@ -21,5 +21,5 @@ export const deleteUser = async (req: Request, res: Response) => {
             }
         })
         .then(() => res.status(200).json({ message: 'Successfully deleted user!' }))
-        .catch((error: Error) => res.status(404).send({ error: error.message }));
+        .catch((error: Error) => res.status(404).json({ error: error.message }));
 };


### PR DESCRIPTION
- this will allow the front-end to make a request to POST /user with the mongoDB id and exchange it for an ingredient service id
- the returned ingredient service id can then be used to make calls within the ingredient service
- also allows the front-end to make a request to DELETE /user now