### PR TITLE
Implement deleting user functionality

### DIFF
--- a/user/src/routes/routes.ts
+++ b/user/src/routes/routes.ts
@@ -7,25 +7,14 @@ export const initializeUserRoutes = (app: Application) => {
     const userRouter = Router();
     app.use('/user', userRouter);
 
-    /* gets a user */
     userRouter.get('/:username', userController.getUser);
-
-    /* posts a user */
     userRouter.post('/', userController.postUser);
-
-    /* deletes a user */
-    userRouter.delete('/', async (req, res) => {
-        res.status(200).send('Working user delete route');
-    });
-
-    /* patches a user */
+    userRouter.delete('/:username', userController.deleteUser);
     userRouter.patch('/', async (req, res) => {
         res.status(200).send('Working user patch route');
     });
 
-    /* user login */
     userRouter.post('/login', postUserLogin);
 
-    /* retrieves recipe suggestion for user */
     userRouter.post('/suggestion', postUserSuggestion);
 };

--- a/user/src/util/location.ts
+++ b/user/src/util/location.ts
@@ -1,5 +1,6 @@
-import { Document } from 'mongoose';
+import { Document, Types } from 'mongoose';
 import { LocationModel } from '../models/location';
+import { UserModel } from '../models/user';
 
 async function createLocation(city: string, province: string, country: string, user: Document): Promise<Document> {
     try {
@@ -20,6 +21,18 @@ async function createLocation(city: string, province: string, country: string, u
     }
 }
 
+async function deleteLocation(locationId: string): Promise<boolean> {
+    if (!locationId) {
+        return true;
+    }
+    const usersAtLocation: Document[] | null = await UserModel.find({ location: Types.ObjectId(locationId) });
+    if (usersAtLocation.length === 1) {
+        await LocationModel.deleteOne({ _id: Types.ObjectId(locationId) });
+        return true;
+    }
+    return false;
+}
+
 async function findLocation(city: string, province: string, country: string): Promise<Document> {
     const location: Document | null = await LocationModel.findOne({ city, province, country });
     if (!location) {
@@ -28,4 +41,4 @@ async function findLocation(city: string, province: string, country: string): Pr
     return location;
 }
 
-export { createLocation, findLocation };
+export { createLocation, deleteLocation, findLocation };

--- a/user/src/util/token.ts
+++ b/user/src/util/token.ts
@@ -18,4 +18,9 @@ async function assignNewToken(user: Document): Promise<string> {
     return newToken;
 }
 
-export { assignNewToken, getUserToken };
+async function verifyUserToken(token: string, username: string): Promise<boolean> {
+    const decoded: any = jwt.verify(token, JWT_SECRET_KEY as string, { maxAge: '168h' });
+    return decoded.username === username;
+}
+
+export { assignNewToken, getUserToken, verifyUserToken };

--- a/user/src/util/user.ts
+++ b/user/src/util/user.ts
@@ -72,6 +72,14 @@ async function getUserAttributes(username: string): Promise<object> {
     return attributes;
 }
 
+async function removeUser(username: string): Promise<Document> {
+    const deletedUser: Document | null = await UserModel.findOneAndDelete({ username });
+    if (!deletedUser) {
+        throw new Error('User could not be found.');
+    }
+    return deletedUser;
+}
+
 async function registerUser(user: Document): Promise<string> {
     // const username: string = user.get('username');
     // return Promise.all([addUserIngredient(username), addUserRecipe(username)]);
@@ -102,4 +110,4 @@ async function verifyUser(username: string, password: string, token: string): Pr
     throw new AuthenticationError('User could not be authenticated.');
 }
 
-export { AVAILABLE_FIELDS, createUser, findUser, getUserAttributes, registerUser, verifyUser };
+export { AVAILABLE_FIELDS, createUser, findUser, getUserAttributes, removeUser, registerUser, verifyUser };


### PR DESCRIPTION
- Implemented the `DELETE /user/:username` endpoint so that a user can only be deleted if the request contains the current user's token (i.e. only the user themselves can delete their user entry in the db because they are the only ones who should have access to their token)
- Will delete the user's location too IFF the user being deleted is the last user with that location 